### PR TITLE
fix race condition

### DIFF
--- a/concurrent/futures/_base.py
+++ b/concurrent/futures/_base.py
@@ -122,8 +122,7 @@ class _AllCompletedWaiter(_Waiter):
         super(_AllCompletedWaiter, self).__init__()
 
     def _decrement_pending_calls(self):
-        self.num_pending_calls -= 1
-        if not self.num_pending_calls:
+        if self.num_pending_calls == len(self.finished_futures):
             self.event.set()
 
     def add_result(self, future):


### PR DESCRIPTION
rather than using a lock like python upstream did, we rely on .append
being thread safe on lists.

see http://bugs.python.org/issue14406 and
https://code.google.com/p/pythonfutures/issues/detail?id=14
